### PR TITLE
Add xPoweredByHeader

### DIFF
--- a/en-US.json
+++ b/en-US.json
@@ -95,7 +95,8 @@
     "showAfterDays": "Sets a number of days after which the product rating widget will be displayed. Using the widget, administrators can give feedback on their Plesk user experience."
   },
   "webserver": {  
-    "nginxCacheEnabled": "(Plesk for Linux) Enables or disables nginx caching."
+    "nginxCacheEnabled": "(Plesk for Linux) Enables or disables nginx caching.",
+    "xPoweredByHeader": "Hide or show X-Powered-By: PleskLin in header."
   }
 }  
   


### PR DESCRIPTION
Since Plesk Obsidian 18.0.31 admin is able to show or hide the X-Powered-By header server-wide without changing or creating custom psa template